### PR TITLE
fix: DeepFMModdelTrain 클래스의 모델 경로를 상대 경로로 수정

### DIFF
--- a/MLOps/app/model/deepfm_train.py
+++ b/MLOps/app/model/deepfm_train.py
@@ -22,9 +22,9 @@ class DeepFMModdelTrain:
         self.feature_names = None
         self.model_input = None
         self.target = "yn"        
-        self.model_path = "/home/ubuntu/MLOps/MLOps/app/model/deepfm_model.pt"
-        self.encoders_path = "/home/ubuntu/MLOps/MLOps/app/model/label_encoders.pkl"
-        self.key2index_path = "/home/ubuntu/MLOps/MLOps/app/model/key2index.pkl"
+        self.model_path = "./deepfm_model.pt"
+        self.encoders_path = "./label_encoders.pkl"
+        self.key2index_path = "./key2index.pkl"
         self.model = None
         self.max_len = None
         self.label_encoders = {}


### PR DESCRIPTION
## 📚 Docs

> ex) #75 

## 💡 Changes

> DeepFMModelTrain 클래스 모델 경로 수정