### PR TITLE
fix: ChatbotAgentService의 임베딩 모델 장치 설정을 CPU로 변경

### DIFF
--- a/MLOps/app/services/chatbot_agent_service.py
+++ b/MLOps/app/services/chatbot_agent_service.py
@@ -48,7 +48,7 @@ class ChatbotAgentService:
         
         self.embedding_function = HuggingFaceEmbeddings(
             model_name="upskyy/bge-m3-korean",
-            model_kwargs={'device': 'cuda'},
+            model_kwargs={'device': 'cpu'},
             encode_kwargs={'normalize_embeddings': True}
         )
         


### PR DESCRIPTION
## 📚 Docs

> ex) #117 

## 💡 Changes

> 모델 장치 cpu 로 변경