### PR TITLE
fix: ElasticsearchService의 정렬 순서를 내림차순에서 오름차순으로 변경

### DIFF
--- a/ELK/app/services/elasticsearch_service.py
+++ b/ELK/app/services/elasticsearch_service.py
@@ -213,7 +213,7 @@ class ElasticsearchService:
                     }
                 },
                 "sort": [
-                    {"createAt": {"order": "desc"}}
+                    {"createAt": {"order": "asc"}}
                 ]
             }
             


### PR DESCRIPTION
## 📚 Docs

> ex) #122 

## 💡 Changes

> 채팅 로그 조회 정렬 순서 오름차순으로 변경