### PR TITLE
fix: scikit-learn 버전 변경 (1.7.0 -> 1.3.0)

### DIFF
--- a/MLOps/requirements.txt
+++ b/MLOps/requirements.txt
@@ -4,7 +4,7 @@ uvicorn==0.24.0
 
 # Recommendation System and ML
 deepctr-torch==0.2.9
-scikit-learn==1.7.0
+scikit-learn==1.3.0
 torch==2.7.1
 torchvision==0.22.1
 torchaudio==2.7.1


### PR DESCRIPTION
## 📚 Docs

> ex) #217 

## 💡 Changes

> LabelEncoder 의 버전 일치
