### PR TITLE
fix: chroma_db_bge의 md5 해시 및 파일 크기 업데이트

### DIFF
--- a/data/chroma_db_bge.dvc
+++ b/data/chroma_db_bge.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 535ab8e8216391782464cf3c89d52ab6.dir
+- md5: 604fc684f03c98f8c31ef3a0e13a544b.dir
   nfiles: 6
   hash: md5
   path: chroma_db_bge
-  size: 114566240
+  size: 92402917


### PR DESCRIPTION
## 📚 Docs

> ex) #248 

## 💡 Changes

> vector db 최신화 (page_content에서 name, address 삭제)