### PR TITLE
fix: MLOps의 requirements.txt에서 catboost를 lightgbm으로 변경

### DIFF
--- a/MLOps/requirements.txt
+++ b/MLOps/requirements.txt
@@ -9,7 +9,7 @@ torch==2.7.1
 torchvision==0.22.1
 torchaudio==2.7.1
 tensorflow==2.19.0
-catboost
+lightgbm
 
 # Data Processing and VectorDB
 pandas==2.3.0


### PR DESCRIPTION
## 📚 Docs

> ex) #263 

## 💡 Changes

> catboost 삭제, lightgbm 추가