### PR TITLE
fix: predict_cong_service.py에서 모델 예측 시 feature 이름 가져오는 방법 수정

### DIFF
--- a/MLOps/app/services/predict_cong_service.py
+++ b/MLOps/app/services/predict_cong_service.py
@@ -90,8 +90,8 @@ def predict_and_save_all_locations():
 
             # 2. 모델별 예측 실행
             for name, model in models.items():
-                final_predict_df = predict_df.reindex(columns=model.feature_names_, fill_value=0)
-                prediction_num = int(model.predict(final_predict_df)[0][0])
+                final_predict_df = predict_df.reindex(columns=model.booster_.feature_name(), fill_value=0)
+                prediction_num = int(model.predict(final_predict_df)[0])
                 prediction_str = CONGEST_LVL_MAP.get(prediction_num, "Unknown")
                 
                 location_result = {


### PR DESCRIPTION
## 📚 Docs

> ex) #270 

## 💡 Changes

> LightGBM 모델 feature 가져오는 방법 수정

> 2차원 배열 사용 불가능한 부분 수정